### PR TITLE
PlainDatePicker view component

### DIFF
--- a/Examples/BlocksApp/BlocksApp.xcodeproj/project.pbxproj
+++ b/Examples/BlocksApp/BlocksApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		001E3A702A37081800C90416 /* Blocks in Frameworks */ = {isa = PBXBuildFile; productRef = 001E3A6F2A37081800C90416 /* Blocks */; };
+		002136DD2B57C2570031AE9A /* PlainDateDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002136DC2B57C2570031AE9A /* PlainDateDemoView.swift */; };
 		0030C2522A99047F00AB2087 /* WatchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0030C2512A99047F00AB2087 /* WatchState.swift */; };
 		0030C2542A99077400AB2087 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 0030C2532A99077400AB2087 /* Settings.bundle */; };
 		003995752AFBF4680051BFCE /* BackgroundTaskView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003995742AFBF4680051BFCE /* BackgroundTaskView.swift */; };
@@ -45,6 +46,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		002136DC2B57C2570031AE9A /* PlainDateDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainDateDemoView.swift; sourceTree = "<group>"; };
 		0030C2512A99047F00AB2087 /* WatchState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchState.swift; sourceTree = "<group>"; };
 		0030C2532A99077400AB2087 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		003995742AFBF4680051BFCE /* BackgroundTaskView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskView.swift; sourceTree = "<group>"; };
@@ -112,6 +114,7 @@
 				0030C2512A99047F00AB2087 /* WatchState.swift */,
 				003995742AFBF4680051BFCE /* BackgroundTaskView.swift */,
 				00A37E2F2B1911A800FA4B5F /* FileSystemExplorerView.swift */,
+				002136DC2B57C2570031AE9A /* PlainDateDemoView.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -317,6 +320,7 @@
 				008D62CC2A56C35800254FD9 /* ImagePickerView.swift in Sources */,
 				003995752AFBF4680051BFCE /* BackgroundTaskView.swift in Sources */,
 				008D62CE2A56C96E00254FD9 /* MailComposeView.swift in Sources */,
+				002136DD2B57C2570031AE9A /* PlainDateDemoView.swift in Sources */,
 				00D1E24A2A36327100E8D275 /* ContentView.swift in Sources */,
 				007314A72AF00BFC0092F234 /* FontsView.swift in Sources */,
 				0030C2522A99047F00AB2087 /* WatchState.swift in Sources */,

--- a/Examples/BlocksApp/BlocksApp/ContentView.swift
+++ b/Examples/BlocksApp/BlocksApp/ContentView.swift
@@ -8,6 +8,7 @@ struct ContentView: View {
         case fonts = "Fonts"
         case bg = "Background test"
         case fileSystemExplorer = "FileSystem Explorer"
+        case plainDateDemo = "PlainDate demo"
 
         var id: String {
             rawValue
@@ -71,6 +72,8 @@ struct ContentView: View {
                     Button("Explore") {
                         explore()
                     }
+                case .plainDateDemo:
+                    PlainDateDemoView()
                 }
             } else {
                 Text("Select a section")

--- a/Examples/BlocksApp/BlocksApp/Features/PlainDateDemoView.swift
+++ b/Examples/BlocksApp/BlocksApp/Features/PlainDateDemoView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+import Blocks
+
+struct PlainDateDemoView: View {
+    @State var plainDate: PlainDate = .init(date: Date())
+    
+    let customDateFormatter: DateFormatter = {
+       var res = DateFormatter()
+        res.dateStyle = .full
+        res.timeStyle = .none
+        return res
+    }()
+    
+    var body: some View {
+        VStack {
+            Text("The current date is:")
+            Text(plainDate.description)
+            
+            LabeledContent("Formatted", value: plainDate.string(with: customDateFormatter))
+            
+            Divider()
+            
+            PlainDatePicker("Change the date", selection: $plainDate)
+        }.padding()
+    }
+}
+
+#Preview {
+    PlainDateDemoView()
+}

--- a/Examples/BlocksCLI/Sources/BlocksCLI/Transport/CurlLikeCommand.swift
+++ b/Examples/BlocksCLI/Sources/BlocksCLI/Transport/CurlLikeCommand.swift
@@ -23,7 +23,7 @@ struct CurlLikeCommand: AsyncParsableCommand {
         }
 
         var urlRequest = URLRequest(url: url)
-        headers.forEach { rawHeader in
+        for rawHeader in headers {
             let subheaders = rawHeader.split(separator: ":", maxSplits: 1)
                 .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines)
                 }

--- a/Examples/BlocksCLI/Sources/BlocksCLI/Vision/ReadBarcodeCommand.swift
+++ b/Examples/BlocksCLI/Sources/BlocksCLI/Vision/ReadBarcodeCommand.swift
@@ -18,7 +18,7 @@ struct ReadBarcodeCommand: ParsableCommand {
             let barcodeDescriptions = try detectBarcodes(in: fileURL)
             print("🎉 Success (count: \(barcodeDescriptions.count))")
 
-            barcodeDescriptions.forEach { item in
+            for item in barcodeDescriptions {
                 print("[\(item.payload ?? "n/a")] — \(item.symbology.rawValue.description)")
             }
 

--- a/Sources/Blocks/PlainDate.swift
+++ b/Sources/Blocks/PlainDate.swift
@@ -64,7 +64,12 @@ public struct PlainDate {
     /// - Parameter alternativeFormatter: The date formatter to use.
     /// - Returns: A string representation of the date.
     public func string(with alternativeFormatter: DateFormatter) -> String {
-        alternativeFormatter.string(from: date)
+        #if DEBUG
+        if alternativeFormatter.timeStyle != .none {
+            fatalError("Runtime issue: please do not use timeStyle in an alternative formatter.")
+        }
+        #endif
+        return alternativeFormatter.string(from: date)
     }
 
     private static func createFormatter(timeZone: TimeZone) -> ISO8601DateFormatter {

--- a/Sources/Blocks/PlainDate.swift
+++ b/Sources/Blocks/PlainDate.swift
@@ -50,8 +50,8 @@ public struct PlainDate {
     // MARK: - Properties
 
     private let formatter: ISO8601DateFormatter
-    private let date: Date
-    private let calendar: Calendar
+    let date: Date
+    let calendar: Calendar
 
     // MARK: - Converting to other formats
 

--- a/Sources/Blocks/UIComponents/PlainDatePicker.swift
+++ b/Sources/Blocks/UIComponents/PlainDatePicker.swift
@@ -26,6 +26,10 @@ public struct PlainDatePicker: View {
     }
 }
 
+// This Swift checks is to prevent the following on GitHub Actions:
+// use of unknown directive '#Preview'
+#if swift(>=5.9)
+
 #Preview {
     @State var plainDate: PlainDate = "2024-01-17"
     return PlainDatePicker("Date", selection: $plainDate)
@@ -53,4 +57,6 @@ public struct PlainDatePicker: View {
     @State var plainDate: PlainDate = "2024-01-17"
     return PlainDatePicker("Date", selection: $plainDate).datePickerStyle(.wheel)
 }
+
+#endif
 #endif

--- a/Sources/Blocks/UIComponents/PlainDatePicker.swift
+++ b/Sources/Blocks/UIComponents/PlainDatePicker.swift
@@ -1,0 +1,56 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+public struct PlainDatePicker: View {
+    private let titleKey: LocalizedStringKey
+    private let selection: Binding<PlainDate>
+
+    public init(
+        _ titleKey: LocalizedStringKey,
+        selection: Binding<PlainDate>
+    ) {
+        self.titleKey = titleKey
+        self.selection = selection
+    }
+
+    public var body: some View {
+        DatePicker(
+            titleKey,
+            selection: Binding(get: {
+                selection.wrappedValue.date
+            }, set: { date in
+                selection.wrappedValue = PlainDate(date: date, calendar: selection.wrappedValue.calendar)
+            }),
+            displayedComponents: [.date]
+        ).environment(\.calendar, selection.wrappedValue.calendar)
+    }
+}
+
+#Preview {
+    @State var plainDate: PlainDate = "2024-01-17"
+    return PlainDatePicker("Date", selection: $plainDate)
+}
+
+#Preview("Compact") {
+    if #available(iOS 14.0, *) {
+        @State var plainDate: PlainDate = "2024-01-17"
+        return PlainDatePicker("Date", selection: $plainDate).datePickerStyle(.compact)
+    } else {
+        return Text("Compact style available from iOS 14.0")
+    }
+}
+
+#Preview("Graphical") {
+    if #available(iOS 14.0, *) {
+        @State var plainDate: PlainDate = "2024-01-17"
+        return PlainDatePicker("Date", selection: $plainDate).datePickerStyle(.graphical)
+    } else {
+        return Text("Graphical style available from iOS 14.0")
+    }
+}
+
+#Preview("Wheel") {
+    @State var plainDate: PlainDate = "2024-01-17"
+    return PlainDatePicker("Date", selection: $plainDate).datePickerStyle(.wheel)
+}
+#endif

--- a/Tests/BlocksTests/Transport/URLLoadingSystemErrorCodesTests.swift
+++ b/Tests/BlocksTests/Transport/URLLoadingSystemErrorCodesTests.swift
@@ -5,6 +5,9 @@ import FoundationNetworking
 import XCTest
 
 final class URLLoadingSystemErrorCodesTests: XCTestCase {
+    // TODO: Explore how to benefit from these extra error info keys
+    // 🔗 https://developer.apple.com/documentation/foundation/url_loading_system/url_loading_system_error_info_keys
+    
     func testErrorCodes() {
         XCTAssertEqual(NSURLErrorUnknown, -1)
 

--- a/Tests/BlocksTests/Transport/URLLoadingSystemErrorCodesTests.swift
+++ b/Tests/BlocksTests/Transport/URLLoadingSystemErrorCodesTests.swift
@@ -7,7 +7,7 @@ import XCTest
 final class URLLoadingSystemErrorCodesTests: XCTestCase {
     // TODO: Explore how to benefit from these extra error info keys
     // 🔗 https://developer.apple.com/documentation/foundation/url_loading_system/url_loading_system_error_info_keys
-    
+
     func testErrorCodes() {
         XCTAssertEqual(NSURLErrorUnknown, -1)
 


### PR DESCRIPTION
A SwiftUI component that wraps `DatePicker` to bind a `PlainDate` in a SwiftUI state at ease. 

![simulator_screenshot_A810FC22-D48E-4024-8106-5615A75F8097](https://github.com/dirtyhenry/swift-blocks/assets/456506/2d514348-32c4-4cf3-81a4-7d4f5b3a953e)
