### PR TITLE
Make PlainDate conform to Sendable

### DIFF
--- a/.changeset/plain-date-sendable.md
+++ b/.changeset/plain-date-sendable.md
@@ -1,0 +1,7 @@
+---
+"swift-blocks": patch
+---
+
+Make PlainDate conform to Sendable
+
+Remove stored ISO8601DateFormatter instance which wasn't Sendable-compliant, and instead create formatter on-demand when needed for string conversion. This maintains the same functionality while making PlainDate thread-safe and suitable for concurrent contexts.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,6 @@
+{
+  "permissions": {
+    "allow": ["Bash(make:*)"],
+    "defaultMode": "acceptEdits"
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,11 @@ jobs:
 
   build_iOS:
     name: Build iOS
-    runs-on: macos-15
+    runs-on: macos-latest
     steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - name: Checkout
         uses: actions/checkout@v4
       - name: Output Xcode version

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 xcuserdata/
 DerivedData/
 .swiftpm
+.claude/
+CLAUDE.md
 
 scratchpad.md
 /Examples/.build

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@
 xcuserdata/
 DerivedData/
 .swiftpm
-.claude/
-CLAUDE.md
 
 scratchpad.md
 /Examples/.build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
+
+## Development Commands
+
+### Building
+
+- `make build` - Build the Swift package for macOS
+- `make build-ios` - Build for iOS platforms
+- `swift build -c release` - Build release configuration
+- `make cli` - Build the BlocksCLI command-line tool
+
+### Testing
+
+- `make test` - Run tests with formatted output
+- `make test-debug` - Run tests with verbose output for debugging
+- `make test-ios` - Run tests on iOS simulator
+- `swift test --filter [TestName]` - Run specific test
+
+### Code Quality
+
+- `make lint` - Check code style and formatting
+- `make format` - Autoformat code using SwiftFormat and SwiftLint
+
+### Documentation
+
+- `make docs` - Generate documentation archive
+- `make serve-docs` - Serve documentation locally
+
+### Versioning
+
+- Uses [@changesets/cli](https://github.com/changesets/changesets) for version
+  management
+- Create changeset files directly in `.changeset/` directory (interactive
+  `yarn changeset` may not work in Claude Code)
+- Changeset file format: `.changeset/description-slug.md` with frontmatter
+  specifying package and change type
+
+Example changeset file:
+
+```markdown
+---
+"swift-blocks": patch
+---
+
+Description of the change
+```
+
+## Architecture Overview
+
+This is a Swift package library providing reusable building blocks with zero
+external dependencies. The codebase follows a modular architecture with clear
+separation of concerns.
+
+### Core Components
+
+**Blocks** (Sources/Blocks/) The main library providing utilities across several
+domains:
+
+- **Transport Layer** - Protocol-based networking abstraction with decorators
+  for logging, retry, and status code checking. Key protocol: `Transport`
+- **PlainDate** - Type for handling dates without time components, supporting
+  ranges and arithmetic
+- **Security** - Keychain management, PKCE implementation for OAuth flows
+- **Web Protocols** - JSON Feed, Sitemap, OpenGraph, Front Matter parsing
+- **Calendar** - iCalendar format support
+- **UI Components** - SwiftUI components like TaskStateButton, PlainDatePicker
+
+**ObjectiveBlocks** (Sources/ObjectiveBlocks/) Legacy Objective-C compatible
+utilities for iOS/macOS development.
+
+### Transport Pattern
+
+The Transport system uses a decorator pattern for composable request handling:
+
+```swift
+URLSession → LoggingTransport → RetryTransport → StatusCodeCheckingTransport
+```
+
+Each transport wrapper adds specific behavior while conforming to the same
+`Transport` protocol.
+
+### Platform Support
+
+- Primary platforms: macOS 10.15+, iOS 13+, tvOS 15+, watchOS 8+
+- Linux support with conditional compilation for platform-specific features
+- Uses `#if os(Linux)` and `#if canImport()` for cross-platform compatibility
+
+### Testing Strategy
+
+- Unit tests in Tests/BlocksTests/ with XCTest
+- Test resources in Tests/BlocksTests/Resources/
+- Example apps for integration testing (BlocksApp, BlocksAppTCA)
+- CI runs on macOS, iOS, and Linux via GitHub Actions
+
+## Key Development Patterns
+
+- **Protocol-Oriented Design**: Core functionality exposed through protocols
+  (Transport, Endpoint)
+- **Async/Await**: Modern concurrency with `@available(iOS 15.0, macOS 12.0, *)`
+  checks
+- **No External Dependencies**: The Blocks library has zero external
+  dependencies
+- **Conditional Compilation**: Platform-specific code isolated with compiler
+  directives

--- a/Sources/Blocks/PlainDate.swift
+++ b/Sources/Blocks/PlainDate.swift
@@ -17,7 +17,7 @@ import Foundation
 ///   print(day)
 /// }
 /// ```
-public struct PlainDate {
+public struct PlainDate: Sendable {
     // MARK: - Creating an instance
 
     /// Creates a plain date from an ISO 8601 string representation.
@@ -32,7 +32,7 @@ public struct PlainDate {
             return nil
         }
 
-        self.init(date: date, calendar: calendar, formatter: formatter)
+        self.init(date: date, calendar: calendar)
     }
 
     /// Creates a plain date from a `Date` object.
@@ -41,21 +41,12 @@ public struct PlainDate {
     ///   - date: The `Date` to represent.
     ///   - calendar: The calendar to use (default is `.current`).
     public init(date: Date, calendar: Calendar = .current) {
-        self.init(
-            date: date, calendar: calendar,
-            formatter: Self.createFormatter(timeZone: calendar.timeZone)
-        )
-    }
-
-    private init(date: Date, calendar: Calendar = .current, formatter: ISO8601DateFormatter) {
-        self.formatter = formatter
         self.date = date
         self.calendar = calendar
     }
 
     // MARK: - Properties
 
-    private let formatter: ISO8601DateFormatter
     let date: Date
     let calendar: Calendar
 
@@ -108,7 +99,7 @@ extension PlainDate: CustomStringConvertible {
 
     /// A string description of the `PlainDate` in ISO 8601 format.
     public var description: String {
-        formatter.string(from: date)
+        Self.createFormatter(timeZone: calendar.timeZone).string(from: date)
     }
 }
 
@@ -117,7 +108,7 @@ extension PlainDate: CustomDebugStringConvertible {
 
     /// A debug description of the `PlainDate` including calendar and time zone details.
     public var debugDescription: String {
-        "\(formatter.string(from: date)) (\(calendar) \(calendar.timeZone) \(date))"
+        "\(Self.createFormatter(timeZone: calendar.timeZone).string(from: date)) (\(calendar) \(calendar.timeZone) \(date))"
     }
 }
 
@@ -146,7 +137,7 @@ extension PlainDate: Strideable {
     /// Advances the date by a specified number of days.
     public func advanced(by value: Int) -> PlainDate {
         let newDate = calendar.date(byAdding: .day, value: value, to: date)!
-        return PlainDate(date: newDate, calendar: calendar, formatter: formatter)
+        return PlainDate(date: newDate, calendar: calendar)
     }
 }
 

--- a/Sources/Blocks/Web/FrontMatter.swift
+++ b/Sources/Blocks/Web/FrontMatter.swift
@@ -10,7 +10,7 @@ struct FrontMatter: Codable {
         case openGraph = "_openGraph"
     }
 
-    public init(feed: JSONFeed.Item, openGraph: OpenGraph) {
+    init(feed: JSONFeed.Item, openGraph: OpenGraph) {
         self.feed = feed
         self.openGraph = openGraph
     }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "version": "0.8.0",
   "packageManager": "yarn@4.4.1",
   "dependencies": {
-    "@changesets/cli": "^2.29.3"
+    "@changesets/cli": "^2.29.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,9 +35,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/assemble-release-plan@npm:^6.0.7":
-  version: 6.0.7
-  resolution: "@changesets/assemble-release-plan@npm:6.0.7"
+"@changesets/assemble-release-plan@npm:^6.0.9":
+  version: 6.0.9
+  resolution: "@changesets/assemble-release-plan@npm:6.0.9"
   dependencies:
     "@changesets/errors": "npm:^0.2.0"
     "@changesets/get-dependents-graph": "npm:^2.1.3"
@@ -45,7 +45,7 @@ __metadata:
     "@changesets/types": "npm:^6.1.0"
     "@manypkg/get-packages": "npm:^1.1.3"
     semver: "npm:^7.5.3"
-  checksum: 10c0/a11bd3c6cf963e61497802f9fb9658ac56a38b2859593e12d3b6aa0926533fc374a02ce81889eb144bbef7c6970e35f3d90206dad5efc61e0e6e96bc7c8fce02
+  checksum: 10c0/128f87975f65d9ceb2c997df186a5deae8637fd3868098bb4fb9772f35fdd3b47883ccbdc2761d0468e60a83ef4e2c1561a8e58f8052bfe2daf1ea046803fe1a
   languageName: node
   linkType: hard
 
@@ -58,17 +58,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/cli@npm:^2.29.3":
-  version: 2.29.3
-  resolution: "@changesets/cli@npm:2.29.3"
+"@changesets/cli@npm:^2.29.5":
+  version: 2.29.5
+  resolution: "@changesets/cli@npm:2.29.5"
   dependencies:
     "@changesets/apply-release-plan": "npm:^7.0.12"
-    "@changesets/assemble-release-plan": "npm:^6.0.7"
+    "@changesets/assemble-release-plan": "npm:^6.0.9"
     "@changesets/changelog-git": "npm:^0.2.1"
     "@changesets/config": "npm:^3.1.1"
     "@changesets/errors": "npm:^0.2.0"
     "@changesets/get-dependents-graph": "npm:^2.1.3"
-    "@changesets/get-release-plan": "npm:^4.0.11"
+    "@changesets/get-release-plan": "npm:^4.0.13"
     "@changesets/git": "npm:^3.0.4"
     "@changesets/logger": "npm:^0.1.1"
     "@changesets/pre": "npm:^2.0.2"
@@ -92,7 +92,7 @@ __metadata:
     term-size: "npm:^2.1.0"
   bin:
     changeset: bin.js
-  checksum: 10c0/6f3fd34d67e8ce9f19b8bc794ed353f0332e6c85016d3c0eceed62023ec3d1f5daa3d378dcfb3d2cdfc852bdb06e93f3df6f7b44076d269b10cc986aa129339d
+  checksum: 10c0/7a83c7a38f636b09d049255180f9abf67b05c49237c7212a03da5f484af117bb5fd071352ba55e7d95b87e1d1aca922c45e5f93bb208ebec65e8d3f8b7cd955b
   languageName: node
   linkType: hard
 
@@ -132,17 +132,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/get-release-plan@npm:^4.0.11":
-  version: 4.0.11
-  resolution: "@changesets/get-release-plan@npm:4.0.11"
+"@changesets/get-release-plan@npm:^4.0.13":
+  version: 4.0.13
+  resolution: "@changesets/get-release-plan@npm:4.0.13"
   dependencies:
-    "@changesets/assemble-release-plan": "npm:^6.0.7"
+    "@changesets/assemble-release-plan": "npm:^6.0.9"
     "@changesets/config": "npm:^3.1.1"
     "@changesets/pre": "npm:^2.0.2"
     "@changesets/read": "npm:^0.6.5"
     "@changesets/types": "npm:^6.1.0"
     "@manypkg/get-packages": "npm:^1.1.3"
-  checksum: 10c0/ce8f033ba6ec83292ab9b2924dbb9307ef3c1af37f2ec125ebddf6ef164bd612d838dcbda26a27c21dfaf348ca205f2ab97663efddddf0b70636102c83639a73
+  checksum: 10c0/908fea784ced29764e02065da6d3d0f1e6590d1c8ac77504efe5879ef183de7a01b2da0be210caa28fc10159125da10540f4bcb6917d371988e50c5b984edd07
   languageName: node
   linkType: hard
 
@@ -917,7 +917,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "swift-blocks@workspace:."
   dependencies:
-    "@changesets/cli": "npm:^2.29.3"
+    "@changesets/cli": "npm:^2.29.5"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- Remove stored `ISO8601DateFormatter` instance which wasn't `Sendable`-compliant
- Create formatter on-demand when needed for string conversion in `description` and `debugDescription` properties

This maintains the same functionality while making PlainDate thread-safe and suitable for concurrent contexts.