### PR TITLE
Add interactive LineEditor with arrow key support

### DIFF
--- a/.changeset/add-line-editor.md
+++ b/.changeset/add-line-editor.md
@@ -1,0 +1,5 @@
+---
+"swift-blocks": minor
+---
+
+Add `LineEditor`, a readline-style interactive line editor with arrow key navigation, word movement, and editing keybindings

--- a/Examples/BlocksCLI/Sources/BlocksCLI/Meta/ReadLineCommand.swift
+++ b/Examples/BlocksCLI/Sources/BlocksCLI/Meta/ReadLineCommand.swift
@@ -1,0 +1,29 @@
+import ArgumentParser
+import Blocks
+import Foundation
+
+struct ReadLineCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "readline",
+        abstract: "Read a line of input from the cli."
+    )
+
+    @Flag(help: "Read input securely (hidden from terminal).")
+    var secure = false
+
+    mutating func run() throws {
+        if secure {
+            guard let input = CLIUtils.readLine(prompt: "Enter secret input (hidden): ", secure: true) else {
+                print("No input was entered.")
+                return
+            }
+            print("You entered: \(input)")
+        } else {
+            guard let input = try CLIUtils.editLine(prompt: "Enter some text: ") else {
+                print("No input was entered.")
+                return
+            }
+            print("You entered: \(input)")
+        }
+    }
+}

--- a/Examples/BlocksCLI/Sources/BlocksCLI/RootCommand.swift
+++ b/Examples/BlocksCLI/Sources/BlocksCLI/RootCommand.swift
@@ -10,6 +10,7 @@ struct BlocksCLI: AsyncParsableCommand {
             GenerateTestCommand.self,
             ReadBarcodeCommand.self,
             GenerateBarcodeCommand.self,
+            ReadLineCommand.self,
             ReadPasswordCommand.self,
             PrintColorsCommand.self,
             LintCopyCommand.self,

--- a/Sources/Blocks/CLIUtils/CLIUtils.swift
+++ b/Sources/Blocks/CLIUtils/CLIUtils.swift
@@ -1,6 +1,25 @@
 import Foundation
 
 public enum CLIUtils {
+    /// Reads a line of input with interactive editing support.
+    ///
+    /// When stdin is a terminal, uses ``LineEditor`` for arrow key navigation,
+    /// word movement, and other readline-style keybindings. Falls back to
+    /// `Swift.readLine()` when stdin is not a terminal (e.g. piped input).
+    ///
+    /// - Parameter prompt: The message displayed to the user, prompting them for input.
+    /// - Returns: The user's input, or `nil` on EOF (Ctrl-D on empty line).
+    /// - Throws: ``LineEditorError/interrupted`` if the user presses Ctrl-C.
+    public static func editLine(prompt: String) throws -> String? {
+        #if canImport(Darwin) || canImport(Glibc)
+        if isatty(STDIN_FILENO) != 0 {
+            return try LineEditor.readLine(prompt: prompt)
+        }
+        #endif
+        print(prompt, terminator: "")
+        return Swift.readLine()
+    }
+
     /// Reads a line of input from the user, optionally in a secure manner.
     ///
     /// This method provides a way to get user input from the command line.

--- a/Sources/Blocks/CLIUtils/CLIUtils.swift
+++ b/Sources/Blocks/CLIUtils/CLIUtils.swift
@@ -12,7 +12,7 @@ public enum CLIUtils {
     /// - Throws: ``LineEditorError/interrupted`` if the user presses Ctrl-C.
     public static func editLine(prompt: String) throws -> String? {
         #if canImport(Darwin) || canImport(Glibc)
-        if isatty(STDIN_FILENO) != 0 {
+        if isatty(STDIN_FILENO) != 0, isatty(STDOUT_FILENO) != 0 {
             return try LineEditor.readLine(prompt: prompt)
         }
         #endif

--- a/Sources/Blocks/CLIUtils/LineEditor.swift
+++ b/Sources/Blocks/CLIUtils/LineEditor.swift
@@ -305,7 +305,25 @@ extension LineEditor {
         }
 
         private func displayWidth(of char: Character) -> Int {
-            char.unicodeScalars.first.map { $0.value > 0xFFFF ? 2 : 1 } ?? 1
+            guard let scalar = char.unicodeScalars.first else { return 1 }
+            let v = scalar.value
+            // East Asian Wide and Fullwidth characters take 2 columns
+            if (0x1100...0x115F).contains(v) || // Hangul Jamo
+                (0x2E80...0x303E).contains(v) || // CJK Radicals, Kangxi, Ideographic
+                (0x3041...0x33BF).contains(v) || // Hiragana, Katakana, Bopomofo, CJK Compat
+                (0x3400...0x4DBF).contains(v) || // CJK Unified Extension A
+                (0x4E00...0x9FFF).contains(v) || // CJK Unified Ideographs
+                (0xA000...0xA4CF).contains(v) || // Yi
+                (0xAC00...0xD7AF).contains(v) || // Hangul Syllables
+                (0xF900...0xFAFF).contains(v) || // CJK Compatibility Ideographs
+                (0xFE30...0xFE6F).contains(v) || // CJK Compatibility Forms
+                (0xFF01...0xFF60).contains(v) || // Fullwidth Forms
+                (0xFFE0...0xFFE6).contains(v) || // Fullwidth Signs
+                (0x20000...0x2FFFD).contains(v) || // CJK Ext B-F, Compat Supplement
+                (0x30000...0x3FFFD).contains(v) { // CJK Ext G+
+                return 2
+            }
+            return 1
         }
     }
 }

--- a/Sources/Blocks/CLIUtils/LineEditor.swift
+++ b/Sources/Blocks/CLIUtils/LineEditor.swift
@@ -1,0 +1,325 @@
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+import Foundation
+
+/// An interactive line editor with arrow key navigation and editing support.
+///
+/// Puts the terminal in raw mode to intercept escape sequences for cursor
+/// movement, and provides readline-style keybindings (Ctrl-A, Ctrl-E, etc.).
+public enum LineEditor {
+    /// Reads a line of input with full editing support.
+    ///
+    /// Supports arrow keys, Home/End, Alt+arrow for word movement,
+    /// Backspace, Delete, Ctrl-A/E/C/D, and UTF-8 input.
+    ///
+    /// - Parameter prompt: The prompt string displayed before the input area.
+    /// - Returns: The entered string, or `nil` if the user pressed Ctrl-D on an empty line.
+    /// - Throws: ``LineEditorError/interrupted`` if the user pressed Ctrl-C.
+    public static func readLine(prompt: String) throws -> String? {
+        TerminalMode.enableRaw()
+        defer { TerminalMode.restore() }
+
+        var buffer = Buffer()
+        redraw(prompt: prompt, buffer: buffer)
+
+        while true {
+            let byte = try readByte()
+
+            switch byte {
+            case 0x0D, 0x0A: // Enter
+                writeString("\n")
+                return buffer.toString()
+
+            case 0x7F, 0x08: // Backspace
+                buffer.deleteBackward()
+                redraw(prompt: prompt, buffer: buffer)
+
+            case 0x04: // Ctrl-D
+                if buffer.isEmpty {
+                    writeString("\n")
+                    return nil
+                }
+
+            case 0x03: // Ctrl-C
+                writeString("^C\n")
+                throw LineEditorError.interrupted
+
+            case 0x01: // Ctrl-A
+                buffer.moveToStart()
+                redraw(prompt: prompt, buffer: buffer)
+
+            case 0x05: // Ctrl-E
+                buffer.moveToEnd()
+                redraw(prompt: prompt, buffer: buffer)
+
+            case 0x15: // Ctrl-U — kill line backward
+                buffer.killToStart()
+                redraw(prompt: prompt, buffer: buffer)
+
+            case 0x0B: // Ctrl-K — kill line forward
+                buffer.killToEnd()
+                redraw(prompt: prompt, buffer: buffer)
+
+            case 0x17: // Ctrl-W — delete word backward
+                buffer.deleteWordBackward()
+                redraw(prompt: prompt, buffer: buffer)
+
+            case 0x1B: // ESC
+                try handleEscape(buffer: &buffer, prompt: prompt)
+
+            case 0x20...0x7E: // Printable ASCII
+                buffer.insert(Character(UnicodeScalar(byte)))
+                redraw(prompt: prompt, buffer: buffer)
+
+            default:
+                if byte >= 0xC0 { // UTF-8 leading byte
+                    let char = try readUTF8(leadingByte: byte)
+                    buffer.insert(char)
+                    redraw(prompt: prompt, buffer: buffer)
+                }
+            }
+        }
+    }
+
+    // MARK: - Escape Sequence Handling
+
+    private static func handleEscape(buffer: inout Buffer, prompt: String) throws {
+        guard let next = tryReadByte(timeoutMs: 50) else {
+            return // Standalone ESC, ignore
+        }
+
+        switch next {
+        case 0x5B: // ESC [  — CSI sequence
+            try handleCSI(buffer: &buffer, prompt: prompt)
+
+        case 0x62: // ESC b — Alt+Left (macOS Terminal)
+            buffer.moveWordLeft()
+            redraw(prompt: prompt, buffer: buffer)
+
+        case 0x66: // ESC f — Alt+Right (macOS Terminal)
+            buffer.moveWordRight()
+            redraw(prompt: prompt, buffer: buffer)
+
+        default:
+            break
+        }
+    }
+
+    private static func handleCSI(buffer: inout Buffer, prompt: String) throws {
+        let byte = try readByte()
+
+        switch byte {
+        case 0x44: // ESC [ D — Left
+            buffer.moveLeft()
+            redraw(prompt: prompt, buffer: buffer)
+
+        case 0x43: // ESC [ C — Right
+            buffer.moveRight()
+            redraw(prompt: prompt, buffer: buffer)
+
+        case 0x48: // ESC [ H — Home
+            buffer.moveToStart()
+            redraw(prompt: prompt, buffer: buffer)
+
+        case 0x46: // ESC [ F — End
+            buffer.moveToEnd()
+            redraw(prompt: prompt, buffer: buffer)
+
+        case 0x33: // ESC [ 3 — possibly Delete
+            let tilde = try readByte()
+            if tilde == 0x7E { // ESC [ 3 ~ — Delete
+                buffer.deleteForward()
+                redraw(prompt: prompt, buffer: buffer)
+            }
+
+        case 0x31: // ESC [ 1 — possibly modified arrow
+            let semi = try readByte()
+            if semi == 0x3B { // semicolon
+                let modifier = try readByte()
+                let arrow = try readByte()
+                if modifier == 0x33 { // Alt modifier (;3)
+                    switch arrow {
+                    case 0x44: // ESC [ 1;3 D — Alt+Left
+                        buffer.moveWordLeft()
+                        redraw(prompt: prompt, buffer: buffer)
+                    case 0x43: // ESC [ 1;3 C — Alt+Right
+                        buffer.moveWordRight()
+                        redraw(prompt: prompt, buffer: buffer)
+                    default:
+                        break
+                    }
+                }
+            }
+
+        default:
+            break
+        }
+    }
+
+    // MARK: - I/O Helpers
+
+    private static func readByte() throws -> UInt8 {
+        var byte: UInt8 = 0
+        let count = read(STDIN_FILENO, &byte, 1)
+        guard count == 1 else {
+            throw LineEditorError.readFailed
+        }
+        return byte
+    }
+
+    private static func tryReadByte(timeoutMs: Int32) -> UInt8? {
+        var pfd = pollfd(fd: STDIN_FILENO, events: Int16(POLLIN), revents: 0)
+        let ready = poll(&pfd, 1, timeoutMs)
+        guard ready > 0 else { return nil }
+        var byte: UInt8 = 0
+        let count = read(STDIN_FILENO, &byte, 1)
+        return count == 1 ? byte : nil
+    }
+
+    private static func readUTF8(leadingByte: UInt8) throws -> Character {
+        var bytes = [leadingByte]
+        let continuationCount: Int
+        if leadingByte & 0xE0 == 0xC0 { continuationCount = 1 }
+        else if leadingByte & 0xF0 == 0xE0 { continuationCount = 2 }
+        else if leadingByte & 0xF8 == 0xF0 { continuationCount = 3 }
+        else { return "\u{FFFD}" }
+
+        for _ in 0..<continuationCount {
+            bytes.append(try readByte())
+        }
+
+        guard let str = String(bytes: bytes, encoding: .utf8), let char = str.first else {
+            return "\u{FFFD}"
+        }
+        return char
+    }
+
+    private static func writeString(_ string: String) {
+        string.utf8CString.withUnsafeBufferPointer { ptr in
+            // Exclude the null terminator
+            _ = write(STDOUT_FILENO, ptr.baseAddress, string.utf8.count)
+        }
+    }
+
+    private static func redraw(prompt: String, buffer: Buffer) {
+        let line = prompt + buffer.toString()
+        let cursorCol = prompt.count + buffer.displayCursor
+        // CR, write line, erase to EOL, reposition cursor
+        writeString("\r\(line)\u{1B}[K\r\u{1B}[\(cursorCol + 1)G")
+    }
+}
+
+// MARK: - Buffer
+
+extension LineEditor {
+    struct Buffer {
+        private(set) var characters: [Character] = []
+        private(set) var cursor: Int = 0
+
+        var isEmpty: Bool { characters.isEmpty }
+
+        var displayCursor: Int {
+            characters[..<cursor].reduce(0) { $0 + displayWidth(of: $1) }
+        }
+
+        mutating func insert(_ char: Character) {
+            characters.insert(char, at: cursor)
+            cursor += 1
+        }
+
+        mutating func deleteBackward() {
+            guard cursor > 0 else { return }
+            cursor -= 1
+            characters.remove(at: cursor)
+        }
+
+        mutating func deleteForward() {
+            guard cursor < characters.count else { return }
+            characters.remove(at: cursor)
+        }
+
+        mutating func moveLeft() {
+            guard cursor > 0 else { return }
+            cursor -= 1
+        }
+
+        mutating func moveRight() {
+            guard cursor < characters.count else { return }
+            cursor += 1
+        }
+
+        mutating func moveToStart() {
+            cursor = 0
+        }
+
+        mutating func moveToEnd() {
+            cursor = characters.count
+        }
+
+        mutating func moveWordLeft() {
+            guard cursor > 0 else { return }
+            cursor -= 1
+            // Skip non-alphanumeric
+            while cursor > 0, !characters[cursor].isLetter, !characters[cursor].isNumber {
+                cursor -= 1
+            }
+            // Skip word characters
+            while cursor > 0, characters[cursor - 1].isLetter || characters[cursor - 1].isNumber {
+                cursor -= 1
+            }
+        }
+
+        mutating func moveWordRight() {
+            guard cursor < characters.count else { return }
+            // Skip non-alphanumeric
+            while cursor < characters.count, !characters[cursor].isLetter, !characters[cursor].isNumber {
+                cursor += 1
+            }
+            // Skip word characters
+            while cursor < characters.count, characters[cursor].isLetter || characters[cursor].isNumber {
+                cursor += 1
+            }
+        }
+
+        mutating func killToStart() {
+            characters.removeFirst(cursor)
+            cursor = 0
+        }
+
+        mutating func killToEnd() {
+            characters.removeSubrange(cursor...)
+        }
+
+        mutating func deleteWordBackward() {
+            let original = cursor
+            moveWordLeft()
+            characters.removeSubrange(cursor..<original)
+        }
+
+        func toString() -> String {
+            String(characters)
+        }
+
+        private func displayWidth(of char: Character) -> Int {
+            char.unicodeScalars.first.map { $0.value > 0xFFFF ? 2 : 1 } ?? 1
+        }
+    }
+}
+
+// MARK: - Errors
+
+public enum LineEditorError: Error, CustomStringConvertible {
+    case interrupted
+    case readFailed
+
+    public var description: String {
+        switch self {
+        case .interrupted: "Interrupted"
+        case .readFailed: "Failed to read from stdin"
+        }
+    }
+}

--- a/Sources/Blocks/CLIUtils/LineEditor.swift
+++ b/Sources/Blocks/CLIUtils/LineEditor.swift
@@ -207,7 +207,8 @@ public enum LineEditor {
 
     private static func redraw(prompt: String, buffer: Buffer) {
         let line = prompt + buffer.toString()
-        let cursorCol = prompt.count + buffer.displayCursor
+        let promptWidth = prompt.unicodeScalars.reduce(0) { $0 + Buffer.displayWidth(of: $1) }
+        let cursorCol = promptWidth + buffer.displayCursor
         // CR, write line, erase to EOL, reposition cursor
         writeString("\r\(line)\u{1B}[K\r\u{1B}[\(cursorCol + 1)G")
     }
@@ -223,7 +224,7 @@ extension LineEditor {
         var isEmpty: Bool { characters.isEmpty }
 
         var displayCursor: Int {
-            characters[..<cursor].reduce(0) { $0 + displayWidth(of: $1) }
+            characters[..<cursor].reduce(0) { $0 + Self.displayWidth(of: $1) }
         }
 
         mutating func insert(_ char: Character) {
@@ -304,8 +305,12 @@ extension LineEditor {
             String(characters)
         }
 
-        private func displayWidth(of char: Character) -> Int {
+        static func displayWidth(of char: Character) -> Int {
             guard let scalar = char.unicodeScalars.first else { return 1 }
+            return displayWidth(of: scalar)
+        }
+
+        static func displayWidth(of scalar: Unicode.Scalar) -> Int {
             let v = scalar.value
             // East Asian Wide and Fullwidth characters take 2 columns
             if (0x1100...0x115F).contains(v) || // Hangul Jamo

--- a/Sources/Blocks/CLIUtils/TerminalMode.swift
+++ b/Sources/Blocks/CLIUtils/TerminalMode.swift
@@ -1,0 +1,32 @@
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+enum TerminalMode {
+    nonisolated(unsafe) private static var original: termios?
+
+    static func enableRaw() {
+        var raw = termios()
+        tcgetattr(STDIN_FILENO, &raw)
+        original = raw
+
+        raw.c_lflag &= ~UInt(ICANON | ECHO | ISIG | IEXTEN)
+
+        withUnsafeMutablePointer(to: &raw.c_cc) { ptr in
+            ptr.withMemoryRebound(to: UInt8.self, capacity: Int(NCCS)) { cc in
+                cc[Int(VMIN)] = 1
+                cc[Int(VTIME)] = 0
+            }
+        }
+
+        tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw)
+    }
+
+    static func restore() {
+        guard var saved = original else { return }
+        tcsetattr(STDIN_FILENO, TCSAFLUSH, &saved)
+        original = nil
+    }
+}

--- a/Sources/Blocks/CLIUtils/TerminalMode.swift
+++ b/Sources/Blocks/CLIUtils/TerminalMode.swift
@@ -12,7 +12,7 @@ enum TerminalMode {
         tcgetattr(STDIN_FILENO, &raw)
         original = raw
 
-        raw.c_lflag &= ~UInt(ICANON | ECHO | ISIG | IEXTEN)
+        raw.c_lflag &= ~tcflag_t(ICANON | ECHO | ISIG | IEXTEN)
 
         withUnsafeMutablePointer(to: &raw.c_cc) { ptr in
             ptr.withMemoryRebound(to: UInt8.self, capacity: Int(NCCS)) { cc in

--- a/Tests/BlocksTests/CLIUtils/LineEditorBufferTests.swift
+++ b/Tests/BlocksTests/CLIUtils/LineEditorBufferTests.swift
@@ -153,6 +153,24 @@ final class LineEditorBufferTests: XCTestCase {
         XCTAssertEqual(buf.cursor, 6)
     }
 
+    // MARK: - Display Width
+
+    func testDisplayCursorASCII() {
+        let buf = buffer("hello")
+        XCTAssertEqual(buf.displayCursor, 5)
+    }
+
+    func testDisplayCursorCJK() {
+        let buf = buffer("你好")
+        XCTAssertEqual(buf.displayCursor, 4)
+    }
+
+    func testDisplayCursorMixed() {
+        // "hi你" = 2 ASCII (width 1 each) + 1 CJK (width 2) = 4
+        let buf = buffer("hi你")
+        XCTAssertEqual(buf.displayCursor, 4)
+    }
+
     // MARK: - Empty Buffer
 
     func testEmptyBuffer() {

--- a/Tests/BlocksTests/CLIUtils/LineEditorBufferTests.swift
+++ b/Tests/BlocksTests/CLIUtils/LineEditorBufferTests.swift
@@ -1,0 +1,174 @@
+@testable import Blocks
+import XCTest
+
+final class LineEditorBufferTests: XCTestCase {
+    // MARK: - Insert
+
+    func testInsertAppends() {
+        var buf = LineEditor.Buffer()
+        buf.insert("a")
+        buf.insert("b")
+        buf.insert("c")
+        XCTAssertEqual(buf.toString(), "abc")
+        XCTAssertEqual(buf.cursor, 3)
+    }
+
+    func testInsertAtMiddle() {
+        var buf = LineEditor.Buffer()
+        buf.insert("a")
+        buf.insert("c")
+        buf.moveLeft()
+        buf.insert("b")
+        XCTAssertEqual(buf.toString(), "abc")
+        XCTAssertEqual(buf.cursor, 2)
+    }
+
+    // MARK: - Delete
+
+    func testDeleteBackward() {
+        var buf = buffer("abc")
+        buf.deleteBackward()
+        XCTAssertEqual(buf.toString(), "ab")
+        XCTAssertEqual(buf.cursor, 2)
+    }
+
+    func testDeleteBackwardAtStart() {
+        var buf = buffer("abc")
+        buf.moveToStart()
+        buf.deleteBackward()
+        XCTAssertEqual(buf.toString(), "abc")
+        XCTAssertEqual(buf.cursor, 0)
+    }
+
+    func testDeleteForward() {
+        var buf = buffer("abc")
+        buf.moveToStart()
+        buf.deleteForward()
+        XCTAssertEqual(buf.toString(), "bc")
+        XCTAssertEqual(buf.cursor, 0)
+    }
+
+    func testDeleteForwardAtEnd() {
+        var buf = buffer("abc")
+        buf.deleteForward()
+        XCTAssertEqual(buf.toString(), "abc")
+        XCTAssertEqual(buf.cursor, 3)
+    }
+
+    // MARK: - Movement
+
+    func testMoveLeftAndRight() {
+        var buf = buffer("abc")
+        buf.moveLeft()
+        XCTAssertEqual(buf.cursor, 2)
+        buf.moveRight()
+        XCTAssertEqual(buf.cursor, 3)
+    }
+
+    func testMoveLeftAtStartIsNoop() {
+        var buf = buffer("abc")
+        buf.moveToStart()
+        buf.moveLeft()
+        XCTAssertEqual(buf.cursor, 0)
+    }
+
+    func testMoveRightAtEndIsNoop() {
+        var buf = buffer("abc")
+        buf.moveRight()
+        XCTAssertEqual(buf.cursor, 3)
+    }
+
+    func testMoveToStartAndEnd() {
+        var buf = buffer("hello")
+        buf.moveToStart()
+        XCTAssertEqual(buf.cursor, 0)
+        buf.moveToEnd()
+        XCTAssertEqual(buf.cursor, 5)
+    }
+
+    // MARK: - Word Movement
+
+    func testMoveWordLeft() {
+        var buf = buffer("hello world")
+        buf.moveWordLeft()
+        XCTAssertEqual(buf.cursor, 6)
+    }
+
+    func testMoveWordLeftSkipsSpaces() {
+        var buf = buffer("hello   world")
+        buf.moveWordLeft()
+        XCTAssertEqual(buf.cursor, 8)
+    }
+
+    func testMoveWordLeftAtStart() {
+        var buf = buffer("hello")
+        buf.moveToStart()
+        buf.moveWordLeft()
+        XCTAssertEqual(buf.cursor, 0)
+    }
+
+    func testMoveWordRight() {
+        var buf = buffer("hello world")
+        buf.moveToStart()
+        buf.moveWordRight()
+        XCTAssertEqual(buf.cursor, 5)
+    }
+
+    func testMoveWordRightSkipsSpaces() {
+        var buf = buffer("hello   world")
+        buf.moveToStart()
+        buf.moveWordRight()
+        XCTAssertEqual(buf.cursor, 5)
+    }
+
+    func testMoveWordRightAtEnd() {
+        var buf = buffer("hello")
+        buf.moveWordRight()
+        XCTAssertEqual(buf.cursor, 5)
+    }
+
+    // MARK: - Kill
+
+    func testKillToStart() {
+        var buf = buffer("hello world")
+        buf.moveWordLeft()
+        buf.killToStart()
+        XCTAssertEqual(buf.toString(), "world")
+        XCTAssertEqual(buf.cursor, 0)
+    }
+
+    func testKillToEnd() {
+        var buf = buffer("hello world")
+        buf.moveToStart()
+        buf.moveWordRight()
+        buf.killToEnd()
+        XCTAssertEqual(buf.toString(), "hello")
+        XCTAssertEqual(buf.cursor, 5)
+    }
+
+    func testDeleteWordBackward() {
+        var buf = buffer("hello world")
+        buf.deleteWordBackward()
+        XCTAssertEqual(buf.toString(), "hello ")
+        XCTAssertEqual(buf.cursor, 6)
+    }
+
+    // MARK: - Empty Buffer
+
+    func testEmptyBuffer() {
+        let buf = LineEditor.Buffer()
+        XCTAssertTrue(buf.isEmpty)
+        XCTAssertEqual(buf.toString(), "")
+        XCTAssertEqual(buf.cursor, 0)
+    }
+
+    // MARK: - Helpers
+
+    private func buffer(_ string: String) -> LineEditor.Buffer {
+        var buf = LineEditor.Buffer()
+        for char in string {
+            buf.insert(char)
+        }
+        return buf
+    }
+}


### PR DESCRIPTION
## Summary

- Add `LineEditor`, a readline-style interactive line editor for terminal input with arrow key navigation, word movement (Alt+arrows), and editing keybindings (Ctrl-A/E/U/K/W)
- Add `TerminalMode` helper for raw terminal mode management
- Add `CLIUtils.editLine(prompt:)` as the public API, with automatic fallback to `Swift.readLine()` for non-TTY input
- Add `ReadLineCommand` to BlocksCLI for testing
- Add unit tests for the `Buffer` type

🤖 Generated with [Claude Code](https://claude.com/claude-code)