### PR TITLE
Make URLRequestHeaderItem Sendable

### DIFF
--- a/.changeset/sendable-urlrequestheaderitem.md
+++ b/.changeset/sendable-urlrequestheaderitem.md
@@ -1,0 +1,5 @@
+---
+"swift-blocks": patch
+---
+
+Conform `URLRequestHeaderItem` to `Sendable` so it can safely cross actor boundaries under strict concurrency checking.

--- a/Sources/Blocks/Transport/URLRequestHeaderItem.swift
+++ b/Sources/Blocks/Transport/URLRequestHeaderItem.swift
@@ -4,7 +4,7 @@ import FoundationNetworking
 #endif
 
 /// A structure representing an individual header item for a `URLRequest`.
-public struct URLRequestHeaderItem {
+public struct URLRequestHeaderItem: Sendable {
     /// The name of the header.
     let name: String
 


### PR DESCRIPTION
## Summary
- Conform `URLRequestHeaderItem` to `Sendable` so it can safely cross actor boundaries under strict concurrency checking.