### PR TITLE
Add iCloud-synchronizable storage option to GenericPasswordKeychainItem

### DIFF
--- a/.changeset/keychain-item-icloud-sync.md
+++ b/.changeset/keychain-item-icloud-sync.md
@@ -1,0 +1,7 @@
+---
+"swift-blocks": minor
+---
+
+Add a `storage` option to `GenericPasswordKeychainItem` to opt into iCloud
+Keychain synchronization (`.localOnly` remains the default), and document the
+security tradeoffs between the two modes.

--- a/.changeset/keychain-item-icloud-sync.md
+++ b/.changeset/keychain-item-icloud-sync.md
@@ -4,4 +4,5 @@
 
 Add a `storage` option to `GenericPasswordKeychainItem` to opt into iCloud
 Keychain synchronization (`.localOnly` remains the default), and document the
-security tradeoffs between the two modes.
+security trade-offs between the two modes. The `.iCloud` mode is unavailable on
+tvOS, which never syncs app keychain items.

--- a/Sources/Blocks/Documentation.docc/Articles/DataManagement.md
+++ b/Sources/Blocks/Documentation.docc/Articles/DataManagement.md
@@ -27,6 +27,11 @@ As a rule of thumb, default to `.localOnly` for device-scoped secrets (for
 example, per-device tokens), and choose `.iCloud` for user-scoped secrets the
 user would otherwise have to re-enter on each of their devices.
 
+`.iCloud` is unavailable on tvOS: tvOS never syncs app keychain items in either
+direction — items stored there never leave the device, and items synced from
+other devices never appear there — so `.localOnly` is the only mode on that
+platform.
+
 Items are stored with the default accessibility
 (`kSecAttrAccessibleWhenUnlocked`), which is compatible with both modes.
 

--- a/Sources/Blocks/Documentation.docc/Articles/DataManagement.md
+++ b/Sources/Blocks/Documentation.docc/Articles/DataManagement.md
@@ -1,7 +1,58 @@
 # Data Management
 
+## Storing secrets in the keychain
+
+``GenericPasswordKeychainItem`` manages _generic password_ keychain items. Each
+item can be stored in one of two modes, chosen at initialization via
+``GenericPasswordKeychainItem/Storage``.
+
+### Choosing between local-only and iCloud storage
+
+**Local-only** (`.localOnly`, the default): the secret never leaves the device.
+This is the strongest confinement — to obtain the secret, an attacker needs
+access to this physical device (or a backup of it). The downside is
+availability: the secret is not accessible from the user's other devices, and
+it is gone for good if the device is lost, wiped, or replaced.
+
+**iCloud** (`.iCloud`): iCloud Keychain syncs the secret with end-to-end
+encryption — Apple cannot read it, and it is protected by the user's device
+passcodes. The upside is that the secret is available on all of the user's
+devices and survives the loss of any single one. The downside is a wider
+exposure surface: the secret now lives on every synced device, so its safety is
+that of the *weakest* enrolled device, and of the Apple ID itself — an account
+takeover combined with the enrollment of a new device through recovery flows
+would expose it.
+
+As a rule of thumb, default to `.localOnly` for device-scoped secrets (for
+example, per-device tokens), and choose `.iCloud` for user-scoped secrets the
+user would otherwise have to re-enter on each of their devices.
+
+Items are stored with the default accessibility
+(`kSecAttrAccessibleWhenUnlocked`), which is compatible with both modes.
+
+### Migrating an existing local item to iCloud
+
+The keychain treats a local item and a synchronizable item with the same label
+and account as two distinct items, and each ``GenericPasswordKeychainItem``
+instance only ever sees the item matching its own storage mode. Migration is
+therefore two instances with the same label and account:
+
+```swift
+let local = GenericPasswordKeychainItem(label: "MyApp", account: "api-token")
+let synced = GenericPasswordKeychainItem(label: "MyApp", account: "api-token", storage: .iCloud)
+
+if let secret = try local.read() {
+    try synced.write(secret)
+    try local.delete()
+}
+```
+
+Read the local copy, write it as a synced item, then delete the local copy so
+the two variants cannot drift apart. The reverse direction works the same way
+if a user opts back out of syncing.
+
 ## Topics
 
 - ``GenericPasswordKeychainItem``
 - ``DataFormatter``
-- ``KeychainError``
+- ``SecurityError``

--- a/Sources/Blocks/Security/GenericPasswordKeychainItem.swift
+++ b/Sources/Blocks/Security/GenericPasswordKeychainItem.swift
@@ -26,7 +26,7 @@ extension Dictionary {
 /// the security tradeoffs between the two modes.
 public final class GenericPasswordKeychainItem {
     /// Where a keychain item is stored, and whether it syncs across the user's devices.
-    public enum Storage {
+    public enum Storage: Sendable {
         /// The secret stays on this device only.
         ///
         /// It is never uploaded anywhere, but it is lost if the device is lost, wiped,
@@ -63,7 +63,7 @@ public final class GenericPasswordKeychainItem {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: account as CFString,
             kSecAttrLabel as String: label as CFString,
-            kSecAttrSynchronizable as String: (storage == .iCloud ? kCFBooleanTrue : kCFBooleanFalse) as AnyObject
+            kSecAttrSynchronizable as String: (storage == .iCloud) as AnyObject
         ]
     }
 

--- a/Sources/Blocks/Security/GenericPasswordKeychainItem.swift
+++ b/Sources/Blocks/Security/GenericPasswordKeychainItem.swift
@@ -16,7 +16,31 @@ extension Dictionary {
 }
 
 /// A convenience class to manage _generic password_ keychain items.
+///
+/// Items are stored with the default accessibility (`kSecAttrAccessibleWhenUnlocked`),
+/// which is compatible with both ``Storage`` modes.
+///
+/// The keychain treats a local item and a synchronizable item with the same label and
+/// account as two distinct items. An instance only ever reads, writes, or deletes the
+/// item matching its own ``storage`` mode. See <doc:DataManagement> for a discussion of
+/// the security tradeoffs between the two modes.
 public final class GenericPasswordKeychainItem {
+    /// Where a keychain item is stored, and whether it syncs across the user's devices.
+    public enum Storage {
+        /// The secret stays on this device only.
+        ///
+        /// It is never uploaded anywhere, but it is lost if the device is lost, wiped,
+        /// or replaced.
+        case localOnly
+
+        /// The secret syncs via iCloud Keychain, end-to-end encrypted, to all devices
+        /// signed into the same Apple ID with iCloud Keychain enabled.
+        ///
+        /// It survives the loss of any single device, at the cost of a wider exposure
+        /// surface: every synced device, and the Apple ID account itself.
+        case iCloud
+    }
+
     /// The label of the keychain item.
     ///
     /// On macOS, as of version 14.1, the Keychain Access app calls this *Name*.
@@ -25,20 +49,25 @@ public final class GenericPasswordKeychainItem {
     /// The account of the keychain item.
     public let account: String
 
-    public init(label: String, account: String) {
+    /// The storage mode of the keychain item.
+    public let storage: Storage
+
+    public init(label: String, account: String, storage: Storage = .localOnly) {
         self.label = label
         self.account = account
+        self.storage = storage
     }
 
-    private var baseDictionary: [String: AnyObject] {
+    var baseDictionary: [String: AnyObject] {
         [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: account as CFString,
-            kSecAttrLabel as String: label as CFString
+            kSecAttrLabel as String: label as CFString,
+            kSecAttrSynchronizable as String: (storage == .iCloud ? kCFBooleanTrue : kCFBooleanFalse) as AnyObject
         ]
     }
 
-    private var query: [String: AnyObject] {
+    var query: [String: AnyObject] {
         baseDictionary.adding(key: kSecMatchLimit as String, value: kSecMatchLimitOne)
     }
 

--- a/Sources/Blocks/Security/GenericPasswordKeychainItem.swift
+++ b/Sources/Blocks/Security/GenericPasswordKeychainItem.swift
@@ -33,12 +33,28 @@ public final class GenericPasswordKeychainItem {
         /// or replaced.
         case localOnly
 
+        #if !os(tvOS)
         /// The secret syncs via iCloud Keychain, end-to-end encrypted, to all devices
         /// signed into the same Apple ID with iCloud Keychain enabled.
         ///
         /// It survives the loss of any single device, at the cost of a wider exposure
         /// surface: every synced device, and the Apple ID account itself.
+        ///
+        /// Unavailable on tvOS: tvOS accepts `kSecAttrSynchronizable` but never syncs
+        /// app keychain items in either direction, so this mode would silently behave
+        /// like ``localOnly`` there. See
+        /// [Apple's documentation](https://developer.apple.com/documentation/security/ksecattrsynchronizable).
         case iCloud
+        #endif
+
+        var isSynchronizable: Bool {
+            switch self {
+            case .localOnly: false
+            #if !os(tvOS)
+            case .iCloud: true
+            #endif
+            }
+        }
     }
 
     /// The label of the keychain item.
@@ -63,7 +79,7 @@ public final class GenericPasswordKeychainItem {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: account as CFString,
             kSecAttrLabel as String: label as CFString,
-            kSecAttrSynchronizable as String: (storage == .iCloud) as AnyObject
+            kSecAttrSynchronizable as String: storage.isSynchronizable as AnyObject
         ]
     }
 

--- a/Tests/BlocksTests/Security/GenericPasswordKeychainItemTests.swift
+++ b/Tests/BlocksTests/Security/GenericPasswordKeychainItemTests.swift
@@ -1,0 +1,40 @@
+#if canImport(Security)
+@testable import Blocks
+import Security
+import XCTest
+
+final class GenericPasswordKeychainItemTests: XCTestCase {
+    func testDefaultStorageIsLocalOnly() {
+        let item = GenericPasswordKeychainItem(label: "Label", account: "Account")
+        XCTAssertEqual(item.storage, .localOnly)
+    }
+
+    func testLocalOnlyBaseDictionary() {
+        let item = GenericPasswordKeychainItem(label: "Label", account: "Account", storage: .localOnly)
+        let dictionary = item.baseDictionary
+
+        XCTAssertEqual(dictionary[kSecClass as String] as? String, kSecClassGenericPassword as String)
+        XCTAssertEqual(dictionary[kSecAttrLabel as String] as? String, "Label")
+        XCTAssertEqual(dictionary[kSecAttrAccount as String] as? String, "Account")
+        XCTAssertEqual(dictionary[kSecAttrSynchronizable as String] as? Bool, false)
+    }
+
+    func testICloudBaseDictionary() {
+        let item = GenericPasswordKeychainItem(label: "Label", account: "Account", storage: .iCloud)
+        let dictionary = item.baseDictionary
+
+        XCTAssertEqual(dictionary[kSecClass as String] as? String, kSecClassGenericPassword as String)
+        XCTAssertEqual(dictionary[kSecAttrLabel as String] as? String, "Label")
+        XCTAssertEqual(dictionary[kSecAttrAccount as String] as? String, "Account")
+        XCTAssertEqual(dictionary[kSecAttrSynchronizable as String] as? Bool, true)
+    }
+
+    func testQueryIncludesSynchronizableAttribute() {
+        let item = GenericPasswordKeychainItem(label: "Label", account: "Account", storage: .iCloud)
+        let query = item.query
+
+        XCTAssertEqual(query[kSecMatchLimit as String] as? String, kSecMatchLimitOne as String)
+        XCTAssertEqual(query[kSecAttrSynchronizable as String] as? Bool, true)
+    }
+}
+#endif

--- a/Tests/BlocksTests/Security/GenericPasswordKeychainItemTests.swift
+++ b/Tests/BlocksTests/Security/GenericPasswordKeychainItemTests.swift
@@ -19,6 +19,7 @@ final class GenericPasswordKeychainItemTests: XCTestCase {
         XCTAssertEqual(dictionary[kSecAttrSynchronizable as String] as? Bool, false)
     }
 
+    #if !os(tvOS)
     func testICloudBaseDictionary() {
         let item = GenericPasswordKeychainItem(label: "Label", account: "Account", storage: .iCloud)
         let dictionary = item.baseDictionary
@@ -36,5 +37,6 @@ final class GenericPasswordKeychainItemTests: XCTestCase {
         XCTAssertEqual(query[kSecMatchLimit as String] as? String, kSecMatchLimitOne as String)
         XCTAssertEqual(query[kSecAttrSynchronizable as String] as? Bool, true)
     }
+    #endif
 }
 #endif


### PR DESCRIPTION
Extends `GenericPasswordKeychainItem` with a nested `Storage` enum (`.localOnly` / `.iCloud`) and a `storage` init parameter defaulting to `.localOnly`, so existing callers are unaffected.

- Every query now pins `kSecAttrSynchronizable` to the instance's storage mode: a `.localOnly` instance never sees the synced variant and vice versa. Existing items keep matching since the keychain treats an absent attribute as `false`.
- Accessibility is unchanged (default `kSecAttrAccessibleWhenUnlocked`, valid for both modes).
- The security tradeoffs between local-only and iCloud storage are documented in plain English on the enum cases and, in more depth, in the `DataManagement` DocC article, along with a recipe for migrating an existing local item to iCloud. Also fixes a stale `KeychainError` reference in that article (the type is `SecurityError`).
- Adds unit tests for query-dictionary construction (no live keychain calls, CI-safe) and a minor changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)